### PR TITLE
Improved build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: python
+sudo: false
 python:
  - 2.6
  - 2.7
  - 3.3
+ - 3.4
  - "pypy"
 
 install:
-    - pip install requests lxml coverage coveralls
+    - travis_retry pip install requests lxml coverage coveralls
 
 script:
     # here we run test suite for setup.py installed package


### PR DESCRIPTION
I added Python 3.4, used travis' new build workers that are based on docker since they boot up faster and I used travis_retry when installing dependencies using pip in order to avoid build failures that are caused by network errors.