### PR TITLE
Added `with` context support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ your terminal, that's why!
 - It can guess if you `iterate over a list`_ (or similar iterable) ...
 - or if iterate over a file ...
 - or if iterate over generator - provided you know it's total length ...
+- or used within a ``with`` context manager ...
 - or not! (no eta, no total steps, no percentage and indicator instead of a bar
   but it works!)
 - And you can easily teach it how to show progress of fat, gzipped xml file
@@ -103,6 +104,19 @@ Iterate over a generator with unknown total number of steps
     [.........#] Step: 1411 | Time: 2min15s
     [........#.] Step: 1412 | Time: 2min16s
     [.......#..] Step: 1413 | Time: 2min17s
+
+
+Iterate over a file with a ``with`` context
+-------------------------------------------
+
+::
+
+    >>> import frogress
+    >>> with frogress.bar(open('/path/to/file', steps_label='Progress')) as f:
+    ...     for line in f:
+    ...         pass # do something cruel with a line
+
+    [###.......] Progress: 3.2MB / 12.8MB |  25.0% | Time: 14min3s | ETA: 19min52s
 
 
 

--- a/frogress/bars.py
+++ b/frogress/bars.py
@@ -27,7 +27,7 @@ class Bar(object):
         self.separator = ' | '
         self.output = sys.stdout
         self.last_shown_at = None
-        self.treshold = 0.05 # in seconds
+        self.treshold = 0.05  # in seconds
 
     def setup_widgets(self, widgets):
         _widgets = widgets or self.DEFAULT_WIDGETS[:]
@@ -71,6 +71,12 @@ class Bar(object):
             raise
 
     next = __next__
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self._iterable.__exit__(*args, **kwargs)
 
     def start(self):
         self.started = datetime.datetime.now()
@@ -140,4 +146,3 @@ class Bar(object):
 
 class TransferBar(Bar):
     DEFAULT_WIDGETS = [BarWidget, TransferWidget, TimerWidget, EtaWidget]
-

--- a/frogress/tests/test_bars.py
+++ b/frogress/tests/test_bars.py
@@ -153,3 +153,9 @@ class TestBar(unittest.TestCase):
     def test_is_iterable(self):
         self.assertIsInstance(self.bar, Iterable)
 
+    def test_context(self):
+        with mock.patch('%s.open' % __name__, mock.mock_open(read_data='first line'),
+                        create=True) as m:
+            with frogress.bar(open('fake_file')) as f:
+                result = f.read()
+        self.assertEqual(result, 'first line')


### PR DESCRIPTION
- So that it can be used with the `with` statement, for example:

```python
with frogress.bar(open('file')) as f:
    for line in f:
        # Do stuff
# File is closed here
```