### PR TITLE
Fix frogress to work on windows

### DIFF
--- a/frogress/utils.py
+++ b/frogress/utils.py
@@ -19,7 +19,7 @@ def get_terminal_width():
         import fcntl
         width = struct.unpack(b'hh',
             fcntl.ioctl(0, termios.TIOCGWINSZ, b'1234'))[1]
-    except (IndexError, IOError):
+    except (IndexError, IOError, ImportError):
         width = None
     return width
 

--- a/frogress/utils.py
+++ b/frogress/utils.py
@@ -1,6 +1,5 @@
 import os
 import struct
-import termios
 
 
 def get_list(count):
@@ -16,6 +15,7 @@ def gen_range(count):
 
 def get_terminal_width():
     try:
+        import termios
         import fcntl
         width = struct.unpack(b'hh',
             fcntl.ioctl(0, termios.TIOCGWINSZ, b'1234'))[1]

--- a/frogress/utils.py
+++ b/frogress/utils.py
@@ -1,4 +1,3 @@
-import fcntl
 import os
 import struct
 import termios
@@ -17,6 +16,7 @@ def gen_range(count):
 
 def get_terminal_width():
     try:
+        import fcntl
         width = struct.unpack(b'hh',
             fcntl.ioctl(0, termios.TIOCGWINSZ, b'1234'))[1]
     except (IndexError, IOError):


### PR DESCRIPTION
frogress does not work on windows due to dependency on fcntl and termios which are not available on windows. This patch catches the import exceptions so that frogress works on windows as well.
