### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ frogress - a progress tool for humans
 .. image:: https://coveralls.io/repos/lukaszb/frogress/badge.png?branch=master
    :target: https://coveralls.io/r/lukaszb/frogress/
 
-.. image:: https://pypip.in/v/frogress/badge.png
+.. image:: https://img.shields.io/pypi/v/frogress.svg
    :target: https://crate.io/packages/frogress/
 
 ::


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20frogress))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `frogress`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.